### PR TITLE
docs: fix empty docker section

### DIFF
--- a/setup/getting-started.md
+++ b/setup/getting-started.md
@@ -26,6 +26,12 @@ A script toolbox to install and update Klipper, Moonraker and Mainsail. KIAUH co
 
 ### Docker
 
+For those who prefer the containerized approach, Docker runs Mainsail in an isolated Docker environment with our pre-built NGINX-basaed image.
+
+{% content-ref url="installation/docker.md" %}
+[docker.md](installation/docker.md)
+{% endcontent-ref %}
+
 ### Manual setup
 
 The rocky road for the daring. For those who want to know how everything is set up manually.

--- a/setup/getting-started.md
+++ b/setup/getting-started.md
@@ -26,7 +26,7 @@ A script toolbox to install and update Klipper, Moonraker and Mainsail. KIAUH co
 
 ### Docker
 
-For those who prefer the containerized approach, Docker runs Mainsail in an isolated Docker environment with our pre-built NGINX-basaed image.
+For those who prefer the containerized approach, Docker runs Mainsail in an isolated Docker environment with our pre-built NGINX-based image.
 
 {% content-ref url="installation/docker.md" %}
 [docker.md](installation/docker.md)


### PR DESCRIPTION
Hello Mainsail team, I hope you don't mind the pr

In the Setup/Installation page in the docs, the section overviewing Docker Install with the hyperlink to the docker.md page was empty. I added a short sentence explaining Docker installation and a hyperlink to the page