### PR TITLE
Grant nginx Required Permissions

### DIFF
--- a/setup/getting-started/manual-setup.md
+++ b/setup/getting-started/manual-setup.md
@@ -555,6 +555,13 @@ cd ~/mainsail
 wget -q -O mainsail.zip https://github.com/mainsail-crew/mainsail/releases/latest/download/mainsail.zip && unzip mainsail.zip && rm mainsail.zip
 ```
 
+### &#x20;Set file permissions for nginx <a href="#nginx-permissions" id="nginx-permissions"></a>
+We need to grant nginx access to the mainsail files
+```bash
+sudo chmod o+x /home/pi
+```
+
+
 Now it should be possible to open the interface: `http://<printer-ip>/`.
 
 ### &#x20;Important macros <a href="#important-macros" id="important-macros"></a>


### PR DESCRIPTION
Using the latest Bookworm Raspberry Pi Lite (x64) OS and the Mainsail manual install guide will generate a 403 Forbidden error when attempting to access the printer due to nginx lacking proper file permissions.

This has been a missing step for several years, but I finally got around to submitting a pull request. There may be a better approach to grant nginx the file permissions it needs. But I'm not sure what that would be.