### PR TITLE
docs: added Printables dark theme

### DIFF
--- a/_data/themes.csv
+++ b/_data/themes.csv
@@ -14,3 +14,4 @@ Vibrant Acryl, Made in collaboration with eliteSchwein,midikeyboard,vibrant-acry
 Frosted Gray,Made with ❤️ by Xapu - based on Acryl (thanks eliteSchwein!),Xapu1337,frosted-gray-mainsail-theme
 Pink Pastel, Made in collaboration with eliteSchwein,midikeyboard,pink-acryl-fluidd-mainsail-theme
 Green Acryl,Please follow installation guide on GitHub page to set custom accent color,tui2019,Mainsail-Green-Acryl
+Printables,(unofficial),8bitmcu,mainsail-printables


### PR DESCRIPTION
I'd love to contribute this theme to the community themes wiki. I've done my best to align with other themes repository structure, but please let me know if there's anything else I need to adjust or provide. Thanks!

https://github.com/8bitmcu/mainsail-printables

![screenshot](https://github.com/user-attachments/assets/c6626b7f-ec6d-402b-8be0-b1cf6e500459)